### PR TITLE
Return acceptable media types in description of NotAcceptable error

### DIFF
--- a/flask_accept/__init__.py
+++ b/flask_accept/__init__.py
@@ -29,7 +29,10 @@ class Acceptor(object):
         if self.use_fallback:
             return self.fallback(*args, **kwargs)
 
-        raise NotAcceptable
+        supported_types = ', '.join(self.accept_handlers)
+        description = '{} Supported entities are: {}'.format(
+            NotAcceptable.description, supported_types)
+        raise NotAcceptable(description)
 
     def support(self, *mimetypes):
         """Register an additional mediatype handler on an existing Acceptor."""

--- a/flask_accept/test/test_versioning.py
+++ b/flask_accept/test/test_versioning.py
@@ -2,7 +2,7 @@ import json
 
 import pytest
 
-from app_for_testing import app
+from app_for_testing import app, index_without_fallback
 
 
 @pytest.mark.parametrize("headers,status_code,version", [
@@ -37,3 +37,6 @@ def test_without_fallback(headers, status_code, version):
         assert rv.status_code == status_code
         if rv.status_code < 300:
             assert version == json.loads(rv.data)['version']
+        else:
+            for accepted_type in index_without_fallback.accept_handlers:
+                assert accepted_type in rv.data


### PR DESCRIPTION
The [RFC for HTTP Status Codes](http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.7) suggests the server should include a list of acceptable entity characteristics when returning a 406 status.

The 406 response will now contain the list of acceptable types. For example:

```
<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
<title>406 Not Acceptable</title>
<h1>Not Acceptable</h1>
<p>The resource identified by the request is only capable of generating
response entities which have content characteristics not acceptable
according to the accept headers sent in the request. Supported entities
are: application/vnd.vendor+json, application/json,
application/vnd.vendor.v2+json, application/vnd.vendor.v1+json</p>
```
